### PR TITLE
Move nat into public subnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform/
+.idea/

--- a/main.tf
+++ b/main.tf
@@ -115,15 +115,15 @@ resource "aws_nat_gateway" "nat" {
   count = local.nat ? (var.tiered_multi_nat ? length(aws_subnet.private_subnets) : 1) : 0
 
   allocation_id = aws_eip.eip[count.index].id
-  subnet_id     = aws_subnet.private_subnets[count.index].id
+  subnet_id     = aws_subnet.subnets[count.index].id
 
   tags = {
     Name = "${var.vpc_name} ${substr(
-      aws_subnet.private_subnets[count.index].availability_zone,
+      aws_subnet.subnets[count.index].availability_zone,
       -1,
       -1,
     )}"
-    Tier = "private"
+    Tier = "public"
   }
 }
 


### PR DESCRIPTION
The current code places nat gateway into private subnets - instead we want nat gateways in public subnets but route from the private subnet to the public subnet and therefore out through nat gateway. 

https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html

You can check example on springload-dev under wagtail-demo or default vpc in redcross. 